### PR TITLE
Substantially improve output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,26 @@ Add reek path:
 **~/.atom/config.cson** (choose Open Your Config in Atom menu).
 
 ```
-'linter-ruby-reek':
+"linter-ruby-reek":
   executablePath: "/path/to/your/reek/here"
 ```
 - Run **`which reek`** to find the path **or** run **`rbenv which reek`** for rbenv users.
 - If you don't, **`reek`** will be the default settings.
+
+### Reek Configuration Path
+
+Add reek configuration path (if it's not default config.reek):
+- Up here in the **settings panel**
+
+**or**
+
+- here:
+**~/.atom/config.cson** (choose Open Your Config in Atom menu).
+
+```
+"linter-ruby-reek":
+  configPath: "test.reek"
+```
 
 **NOTE - 1**:
 - Open atom from the terminal if you don't see the linter working, it's Atom

--- a/lib/linter-ruby-reek.coffee
+++ b/lib/linter-ruby-reek.coffee
@@ -48,7 +48,6 @@ module.exports =
               json = data.split('\n')
 
             exit: (code) ->
-              console.log "code is #{code}"
               return resolve [] unless code is 2
 
               info        = {"errors": []}
@@ -60,9 +59,17 @@ module.exports =
               return resolve [] unless info?
               return resolve [] if info.passed
 
+              docLinkPattern = ///\[(.+)\]$///i
+
               resolve info.errors.map (error) ->
+                errorName = error.split(':')[2].trim()
+                errorDesc = error.split(':')[3].split('[')[0].trim()
+                docLink   = error.match(docLinkPattern)[1]
+                errBadge  = '<span class="badge badge-flexible">reek</span>'
+                errHtml   = "#{errBadge} <a href='#{docLink}'>#{errorName}</a>: #{errorDesc}"
+
                 type: 'warning'
-                text: error.split(':')[2]           # text: error.message,
+                html: errHtml
                 filePath: filePath                  # filePath: error.file or filePath,
                 range: [
                   [parseInt(error.split(':')[1])-1, 0],

--- a/lib/linter-ruby-reek.coffee
+++ b/lib/linter-ruby-reek.coffee
@@ -63,7 +63,7 @@ module.exports =
 
               resolve info.errors.map (error) ->
                 errorName = error.split(':')[2].trim()
-                errorDesc = error.split(':')[3].split('[')[0].trim()
+                errorDesc = error.split(': ')[2].split('[http')[0].trim()
                 docLink   = error.match(docLinkPattern)[1]
                 errBadge  = '<span class="badge badge-flexible">reek</span>'
                 errHtml   = "#{errBadge} <a href='#{docLink}'>#{errorName}</a>: #{errorDesc}"


### PR DESCRIPTION
<img width="583" alt="screen_1" src="https://cloud.githubusercontent.com/assets/455338/12644653/18ae754e-c5cd-11e5-8f03-0be588f645f5.png">

@ahmadseleem I'm so sorry for bothering you all the time, but I decided to improve the output a little bit in my fork (+ it fixes the same [issue](https://github.com/ahmadseleem/linter-ruby-reek/pull/3)) as and I think it could be possibly interesting to you too. Also added information about `reek configuration` option to README file. Whenever you have time, check this one. Thanks in advance. 😳

**BTW**: Using this new `reek configuration` feature I found a few minor things may be worth mentioning in the documentation. One of them is that parsing yaml within reek causes an error `Error: Invalid configuration file /some/path/to/project/config.reek, error is undefined method `load_file' for Psych:Module` which seems to be a known `Psych` [issue](https://github.com/sferik/t/issues/258). Since it's someone else's issue, you may consider just mentioning it in README as a one more NOTE. I deleted Psych for my root directory (`/`) gemset (where `reek` is executed on my machine), and `linter-ruby-reek` started to work. Before that it was just silent (internally getting code `1` from `reek` command). 
